### PR TITLE
refactor: remove webworker lib and use RequestInit body type

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -14,7 +14,7 @@ type Middleware<
 	CommandOutput extends Jsonifiable | unknown = unknown,
 > = (input: CommandInput, output: CommandOutput) => CommandOutput;
 
-type Body = BodyInit | null | Uint8Array
+type Body = RequestInit['body'] | null | Uint8Array
 
 export abstract class Command<
 	// WARN: this must be kept compatible with the Client Input and Output types

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,7 +7,7 @@ export type Resolver<T = unknown> = () => T | Promise<T>;
 export type ResolvableHeaders = Record<string, string | Resolver<string>>;
 
 export type FetcherParams = {
-  body?: BodyInit | Uint8Array | null;
+  body?: RequestInit['body'] | Uint8Array | null;
   url: URL;
   method: HttpMethod;
   headers?: Record<string, string>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
 		"allowImportingTsExtensions": true,
 		"noEmit": true,
 		"noPropertyAccessFromIndexSignature": false,
-		"lib": ["es2024", "webworker"]
+		"lib": ["es2024"]
 	},
 	"include": ["./src", "test", "./lib"],
 	"exclude": ["./dist", "node_modules"]


### PR DESCRIPTION
Removes the `webworker` tsconfig lib and replaces `BodyInit` with `RequestInit['body']` to maintain type safety without the unnecessary webworker dependency.