### PR TITLE
fix: annotate URLSearchParams map return as tuple

### DIFF
--- a/lib/rest-service-client.ts
+++ b/lib/rest-service-client.ts
@@ -63,7 +63,7 @@ export class RestServiceClient<
 		const url = new URL(`.${pathname}`, this.#base);
 		url.search = query
 			? new URLSearchParams(
-				Object.entries(query).map(([k, v]) => [k, v?.toString() || '']),
+				Object.entries(query).map(([k, v]): [string, string] => [k, v?.toString() ?? '']),
 			).toString()
 			: '';
 


### PR DESCRIPTION
Without `webworker` lib, `@types/node`'s `URLSearchParams` requires `[string, string]` tuples. Annotate the arrow function return type explicitly.